### PR TITLE
Install sumamry_resample script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,7 @@ endif()
 
 add_subdirectory( lib )
 add_subdirectory( applications )
-
+add_subdirectory( bin )
 
 if (ENABLE_PYTHON)
    if (ERT_WINDOWS)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,0 +1,3 @@
+if (ENABLE_PYTHON)
+    install(PROGRAMS summary_resample DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+endif()


### PR DESCRIPTION
When there is a package `ecl` and `tests.ecl` there becomes some import name conflicts.